### PR TITLE
Prevent error window upon Anki opening when Discord is closed

### DIFF
--- a/rpc.py
+++ b/rpc.py
@@ -148,7 +148,7 @@ class WinDiscordIpcClient(DiscordIpcClient):
             try:
                 self._f = open(path, "w+b")
             except OSError as e:
-                logger.error("failed to open {!r}: {}".format(path, e))
+                logger.debug("failed to open {!r}: {}".format(path, e))
             else:
                 break
         else:
@@ -180,7 +180,7 @@ class UnixDiscordIpcClient(DiscordIpcClient):
             try:
                 self._sock.connect(path)
             except OSError as e:
-                logger.error("failed to open {!r}: {}".format(path, e))
+                logger.debug("failed to open {!r}: {}".format(path, e))
             else:
                 break
         else:


### PR DESCRIPTION
When discord is not opened and that the discord files doesn't exist, log a debug message instead of an error, to avoid anki opening an error window.